### PR TITLE
Add minimal buttons UI and X-release for kidnapped NPCs

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -137,6 +137,9 @@ CreateThread(function()
                 DisableControlAction(0, 22, true)
                 DisableControlAction(0, 44, true)
             end
+            if IsControlJustPressed(0, 73) then -- X key
+                stopCarrying()
+            end
         end
         Wait(0)
     end

--- a/html/app.js
+++ b/html/app.js
@@ -1,13 +1,13 @@
-let state = { netId: null, carrying: false };
+let state = { netId: null };
 
 window.addEventListener('message', (e) => {
   const data = e.data || {};
+  const panel = document.getElementById('panel');
   if (data.action === 'open') {
     state.netId = data.netId;
-    state.carrying = !!data.carrying;
-    document.getElementById('panel').classList.remove('hidden');
+    panel.classList.remove('hidden');
   } else if (data.action === 'hide') {
-    document.getElementById('panel').classList.add('hidden');
+    panel.classList.add('hidden');
   }
 });
 
@@ -19,19 +19,27 @@ const post = (name, body = {}) => {
   }).catch(()=>{});
 };
 
+document.getElementById('kidnapBtn').addEventListener('click', () => {
+  post('kidnap', { netId: state.netId });
+  post('close', {});
+});
+
+document.getElementById('kneelBtn').addEventListener('click', () => {
+  post('kneel', { netId: state.netId });
+  post('close', {});
+});
+
+document.getElementById('releaseBtn').addEventListener('click', () => {
+  post('release', {});
+  post('close', {});
+});
+
+document.getElementById('closeBtn').addEventListener('click', () => {
+  post('close', {});
+});
+
 document.addEventListener('keydown', (e) => {
-  const key = e.key.toLowerCase();
-  if (document.getElementById('panel').classList.contains('hidden')) return;
-  if (key === 'y') {
-    post('kidnap', { netId: state.netId });
-    post('close', {});
-  } else if (key === 'u') {
-    post('kneel', { netId: state.netId });
-    post('close', {});
-  } else if (key === 'o') {
-    post('release', {});
-    post('close', {});
-  } else if (key === 'escape') {
+  if (e.key.toLowerCase() === 'escape') {
     post('close', {});
   }
 });

--- a/html/index.html
+++ b/html/index.html
@@ -10,10 +10,11 @@
 <body>
   <div id="panel" class="panel hidden">
     <h2>Menu de NPC</h2>
-    <p>[Y] Secuestrar</p>
-    <p>[U] Arrodillar</p>
-    <p>[O] Dejar libre</p>
-    <p>[ESC] Cerrar</p>
+    <button id="kidnapBtn">Secuestrar</button>
+    <button id="kneelBtn">Arrodillar</button>
+    <button id="releaseBtn">Dejar libre</button>
+    <button id="closeBtn">Cerrar</button>
+    <p class="hint">Pulsa X para soltar</p>
   </div>
   <script src="app.js"></script>
 </body>

--- a/html/style.css
+++ b/html/style.css
@@ -9,5 +9,16 @@ body{margin:0;padding:0;background:transparent}
   border:1px solid rgba(255,255,255,0.1);
 }
 .panel h2{margin:0 0 10px 0; font-size:18px; text-align:center;}
-.panel p{margin:4px 0; text-align:center;}
+.panel button{
+  width:100%;
+  margin:4px 0;
+  padding:8px;
+  background:rgba(255,255,255,0.1);
+  color:#fff;
+  border:1px solid rgba(255,255,255,0.2);
+  border-radius:8px;
+  cursor:pointer;
+}
+.panel button:hover{background:rgba(255,255,255,0.2);}
+.hint{margin:8px 0 0;text-align:center;font-size:12px;opacity:0.7;}
 .hidden{display:none}


### PR DESCRIPTION
## Summary
- replace text instructions with simple clickable buttons in NPC interface
- style the menu for a minimal look and add on-screen hint to use X for release
- allow releasing kidnapped NPCs by pressing the X key

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b65c0517c483279c47ce6155486b87