### PR TITLE
feat: redesign npc menu interface

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -123,6 +123,24 @@ RegisterNUICallback('release', function(_, cb)
     cb('ok')
 end)
 
+RegisterNUICallback('melee', function(data, cb)
+    local netId = data.netId
+    local ped = NetworkGetEntityFromNetworkId(netId)
+    if ped ~= 0 and isValidNpc(ped, PlayerPedId()) then
+        TaskCombatPed(ped, PlayerPedId(), 0, 16)
+    end
+    cb('ok')
+end)
+
+RegisterNUICallback('threaten', function(data, cb)
+    local netId = data.netId
+    local ped = NetworkGetEntityFromNetworkId(netId)
+    if ped ~= 0 and isValidNpc(ped, PlayerPedId()) then
+        threatenPed(ped, PlayerPedId())
+    end
+    cb('ok')
+end)
+
 CreateThread(function()
     while true do
         if carrying then

--- a/html/app.js
+++ b/html/app.js
@@ -18,28 +18,24 @@ const post = (name, body = {}) => {
     body: JSON.stringify(body)
   }).catch(()=>{});
 };
-
-document.getElementById('kidnapBtn').addEventListener('click', () => {
-  post('kidnap', { netId: state.netId });
-  post('close', {});
-});
-
-document.getElementById('kneelBtn').addEventListener('click', () => {
-  post('kneel', { netId: state.netId });
-  post('close', {});
-});
-
-document.getElementById('releaseBtn').addEventListener('click', () => {
-  post('release', {});
-  post('close', {});
-});
-
-document.getElementById('closeBtn').addEventListener('click', () => {
-  post('close', {});
-});
-
 document.addEventListener('keydown', (e) => {
-  if (e.key.toLowerCase() === 'escape') {
+  const key = e.key.toLowerCase();
+  if (key === 'escape') {
+    post('close', {});
+  } else if (key === 'e') {
+    post('kidnap', { netId: state.netId });
+    post('close', {});
+  } else if (key === 'x') {
+    post('kneel', { netId: state.netId });
+    post('close', {});
+  } else if (key === 'y') {
+    post('melee', { netId: state.netId });
+    post('close', {});
+  } else if (key === 'k') {
+    post('threaten', { netId: state.netId });
+    post('close', {});
+  } else if (key === 'g') {
+    post('release', {});
     post('close', {});
   }
 });

--- a/html/index.html
+++ b/html/index.html
@@ -9,12 +9,11 @@
 </head>
 <body>
   <div id="panel" class="panel hidden">
-    <h2>Menu de NPC</h2>
-    <button id="kidnapBtn">Secuestrar</button>
-    <button id="kneelBtn">Arrodillar</button>
-    <button id="releaseBtn">Dejar libre</button>
-    <button id="closeBtn">Cerrar</button>
-    <p class="hint">Pulsa X para soltar</p>
+    <div class="option"><span class="key">E</span><span>Rob</span></div>
+    <div class="option"><span class="key">X</span><span>Restrain</span></div>
+    <div class="option"><span class="key">Y</span><span>Melee</span></div>
+    <div class="option"><span class="key">K</span><span>Threaten</span></div>
+    <div class="option"><span class="key">G</span><span>Let Go</span></div>
   </div>
   <script src="app.js"></script>
 </body>

--- a/html/style.css
+++ b/html/style.css
@@ -1,24 +1,19 @@
 *{box-sizing:border-box;font-family:Arial,Helvetica,sans-serif}
 body{margin:0;padding:0;background:transparent}
 .panel{
-  position: absolute; left: 50%; top: 70%;
-  transform: translate(-50%,-50%);
-  background: rgba(20,20,20,0.9);
-  color:#fff; padding:14px 16px; border-radius:14px;
-  min-width: 320px; box-shadow:0 10px 30px rgba(0,0,0,0.35);
+  position:absolute;left:50%;top:50%;
+  transform:translate(-50%,-50%);
+  background:rgba(20,20,20,0.9);
+  color:#fff;padding:14px 16px;border-radius:14px;
+  box-shadow:0 10px 30px rgba(0,0,0,0.35);
   border:1px solid rgba(255,255,255,0.1);
+  display:flex;flex-direction:column;gap:6px;
 }
-.panel h2{margin:0 0 10px 0; font-size:18px; text-align:center;}
-.panel button{
-  width:100%;
-  margin:4px 0;
-  padding:8px;
-  background:rgba(255,255,255,0.1);
-  color:#fff;
-  border:1px solid rgba(255,255,255,0.2);
-  border-radius:8px;
-  cursor:pointer;
+.option{display:flex;align-items:center;font-size:16px}
+.key{
+  width:24px;height:24px;margin-right:8px;
+  background:#fff;color:#333;font-weight:bold;
+  border-radius:50%;display:flex;
+  align-items:center;justify-content:center;
 }
-.panel button:hover{background:rgba(255,255,255,0.2);}
-.hint{margin:8px 0 0;text-align:center;font-size:12px;opacity:0.7;}
 .hidden{display:none}


### PR DESCRIPTION
## Summary
- redesign NPC interaction panel to list key actions like Rob, Restrain, Melee, Threaten, and Let Go
- add keyboard listeners to trigger actions instead of buttons
- support melee and threaten callbacks on the client

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b65d5fa8188327aa0e313b22799afd