### PR TITLE
Simplify NPC interaction menu

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -123,24 +123,6 @@ RegisterNUICallback('release', function(_, cb)
     cb('ok')
 end)
 
-RegisterNUICallback('melee', function(data, cb)
-    local netId = data.netId
-    local ped = NetworkGetEntityFromNetworkId(netId)
-    if ped ~= 0 and isValidNpc(ped, PlayerPedId()) then
-        TaskCombatPed(ped, PlayerPedId(), 0, 16)
-    end
-    cb('ok')
-end)
-
-RegisterNUICallback('threaten', function(data, cb)
-    local netId = data.netId
-    local ped = NetworkGetEntityFromNetworkId(netId)
-    if ped ~= 0 and isValidNpc(ped, PlayerPedId()) then
-        threatenPed(ped, PlayerPedId())
-    end
-    cb('ok')
-end)
-
 CreateThread(function()
     while true do
         if carrying then

--- a/html/app.js
+++ b/html/app.js
@@ -28,12 +28,6 @@ document.addEventListener('keydown', (e) => {
   } else if (key === 'x') {
     post('kneel', { netId: state.netId });
     post('close', {});
-  } else if (key === 'y') {
-    post('melee', { netId: state.netId });
-    post('close', {});
-  } else if (key === 'k') {
-    post('threaten', { netId: state.netId });
-    post('close', {});
   } else if (key === 'g') {
     post('release', {});
     post('close', {});

--- a/html/index.html
+++ b/html/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -9,11 +9,9 @@
 </head>
 <body>
   <div id="panel" class="panel hidden">
-    <div class="option"><span class="key">E</span><span>Rob</span></div>
-    <div class="option"><span class="key">X</span><span>Restrain</span></div>
-    <div class="option"><span class="key">Y</span><span>Melee</span></div>
-    <div class="option"><span class="key">K</span><span>Threaten</span></div>
-    <div class="option"><span class="key">G</span><span>Let Go</span></div>
+    <div class="option"><span class="key">E</span><span>Secuestrar</span></div>
+    <div class="option"><span class="key">X</span><span>Arrodillar</span></div>
+    <div class="option"><span class="key">G</span><span>Dejar ir</span></div>
   </div>
   <script src="app.js"></script>
 </body>

--- a/html/style.css
+++ b/html/style.css
@@ -3,10 +3,10 @@ body{margin:0;padding:0;background:transparent}
 .panel{
   position:absolute;left:50%;top:50%;
   transform:translate(-50%,-50%);
-  background:rgba(20,20,20,0.9);
+  background:transparent;
   color:#fff;padding:14px 16px;border-radius:14px;
-  box-shadow:0 10px 30px rgba(0,0,0,0.35);
-  border:1px solid rgba(255,255,255,0.1);
+  box-shadow:none;
+  border:none;
   display:flex;flex-direction:column;gap:6px;
 }
 .option{display:flex;align-items:center;font-size:16px}


### PR DESCRIPTION
## Summary
- Show only Secuestrar, Arrodillar, and Dejar ir options in the UI
- Remove dark panel background for cleaner buttons
- Drop unused melee and threaten NUI callbacks and key bindings

## Testing
- `node --check html/app.js`
- `luac -p client/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b65ec94b788327b67b0adc9d90d04c