### PR TITLE
Fix missing GetEntityRightVector in client script

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -37,6 +37,11 @@ local function threatenPed(ped, playerPed)
     TaskHandsUp(ped, -1, playerPed, -1, true)
 end
 
+local function GetEntityRightVector(entity)
+    local rightX, rightY, rightZ = GetEntityMatrix(entity)
+    return vector3(rightX, rightY, rightZ)
+end
+
 local function getPedScreenCoords(ped)
     local coords = GetPedBoneCoords(ped, 31086, 0.0, 0.0, 0.0)
     -- shift from head to right shoulder and slightly down


### PR DESCRIPTION
## Summary
- define `GetEntityRightVector` helper using `GetEntityMatrix`

## Testing
- `luac -p client/main.lua` *(fails: command not found)*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b6633373d88327a7e84a9c4000476e