### PR TITLE
Add carry overlay for release and kneel options

### DIFF
--- a/html/app.js
+++ b/html/app.js
@@ -3,6 +3,7 @@ let state = { netId: null, carrying: false };
 window.addEventListener('message', (e) => {
   const data = e.data || {};
   const panel = document.getElementById('panel');
+  const carry = document.getElementById('carry');
   if (data.action === 'open') {
     state.netId = data.netId;
     state.carrying = data.carrying;
@@ -21,6 +22,13 @@ window.addEventListener('message', (e) => {
   } else if (data.action === 'position') {
     panel.style.left = `${data.x * 100}%`;
     panel.style.top = `${data.y * 100}%`;
+  } else if (data.action === 'carrying') {
+    state.carrying = data.show;
+    if (data.show) {
+      carry.classList.remove('hidden');
+    } else {
+      carry.classList.add('hidden');
+    }
   }
 });
 
@@ -51,10 +59,10 @@ document.addEventListener('keydown', (e) => {
   } else if (key === 'e' && !state.carrying) {
     post('kidnap', { netId: state.netId });
     post('close', {});
-  } else if (key === 'x') {
+  } else if (key === 'g') {
     post('kneel', { netId: state.netId });
     post('close', {});
-  } else if (key === 'g') {
+  } else if (key === 'x') {
     post('release', {});
     post('close', {});
   }

--- a/html/index.html
+++ b/html/index.html
@@ -10,8 +10,12 @@
 <body>
   <div id="panel" class="panel hidden">
     <button class="option" data-action="kidnap"><span class="key">E</span><span>Secuestrar</span></button>
-    <button class="option" data-action="kneel"><span class="key">X</span><span>Arrodillar</span></button>
-    <button class="option" data-action="release"><span class="key">G</span><span>Dejar ir</span></button>
+    <button class="option" data-action="kneel"><span class="key">G</span><span>Arrodillar</span></button>
+    <button class="option" data-action="release"><span class="key">X</span><span>Soltar</span></button>
+  </div>
+  <div id="carry" class="carry hidden">
+    <div class="option"><span class="key">X</span><span>Soltar</span></div>
+    <div class="option"><span class="key">G</span><span>Arrodillar</span></div>
   </div>
   <script src="app.js"></script>
 </body>

--- a/html/style.css
+++ b/html/style.css
@@ -25,3 +25,14 @@ body{margin:0;padding:0;background:transparent}
     align-items:center;justify-content:center;
   }
 .hidden{display:none}
+.carry{
+    position:absolute;
+    top:50%;
+    right:20px;
+    transform:translateY(-50%);
+    background:transparent;
+    display:flex;
+    flex-direction:column;
+    gap:6px;
+    color:#fff;
+}


### PR DESCRIPTION
## Summary
- show right-side carry overlay with X to release and G to kneel
- swap NUI key bindings for release and kneel
- allow kneeling carried NPC with G key

## Testing
- `find . -name "*.lua" -print0 | xargs -0 -n1 luac -p && echo "luac success"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b66de34dfc8327a7a36ac66880a149