### PR TITLE
fix: hide carry prompt unless kidnapping

### DIFF
--- a/html/style.css
+++ b/html/style.css
@@ -24,7 +24,7 @@ body{margin:0;padding:0;background:transparent}
     border-radius:50%;display:flex;
     align-items:center;justify-content:center;
   }
-.hidden{display:none}
+.hidden{display:none !important}
 .carry{
     position:absolute;
     top:50%;


### PR DESCRIPTION
## Summary
- ensure `.hidden` class overrides carry layout so carry prompt is only shown when actually carrying an NPC

## Testing
- `luac -p client/main.lua`
- `luac -p server/main.lua`
- `node --check html/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b671bdb1dc8327a03dbe13460bf2c0