### PR TITLE
Allow movement while aiming and add extra options

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -56,11 +56,13 @@ local function openNuiForPed(ped)
     local _, x, y = getPedScreenCoords(ped)
     SendNUIMessage({ action = 'open', netId = netId, carrying = carrying, x = x, y = y })
     SetNuiFocus(true, false)
+    SetNuiFocusKeepInput(true)
 end
 
 local function closeNui()
     SendNUIMessage({ action = 'hide' })
     SetNuiFocus(false, false)
+    SetNuiFocusKeepInput(false)
 end
 
 RegisterNUICallback('close', function(_, cb)

--- a/html/app.js
+++ b/html/app.js
@@ -12,18 +12,10 @@ window.addEventListener('message', (e) => {
     panel.classList.remove('hidden');
     panel.querySelectorAll('.option').forEach((btn) => {
       const action = btn.dataset.action;
-      if (state.carrying) {
-        if (action === 'kidnap') {
-          btn.classList.add('hidden');
-        } else {
-          btn.classList.remove('hidden');
-        }
+      if (state.carrying && action === 'kidnap') {
+        btn.classList.add('hidden');
       } else {
-        if (action === 'kidnap') {
-          btn.classList.remove('hidden');
-        } else {
-          btn.classList.add('hidden');
-        }
+        btn.classList.remove('hidden');
       }
     });
   } else if (data.action === 'hide') {
@@ -68,10 +60,10 @@ document.addEventListener('keydown', (e) => {
   } else if (key === 'e' && !state.carrying) {
     post('kidnap', { netId: state.netId });
     post('close', {});
-  } else if (key === 'g' && state.carrying) {
+  } else if (key === 'g') {
     post('kneel', { netId: state.netId });
     post('close', {});
-  } else if (key === 'x' && state.carrying) {
+  } else if (key === 'x') {
     post('release', {});
     post('close', {});
   }

--- a/html/index.html
+++ b/html/index.html
@@ -11,10 +11,10 @@
   <div id="panel" class="panel hidden">
     <button class="option" data-action="kidnap"><span class="key">E</span><span>Secuestrar</span></button>
     <button class="option" data-action="kneel"><span class="key">G</span><span>Arrodillar</span></button>
-    <button class="option" data-action="release"><span class="key">X</span><span>Soltar</span></button>
+    <button class="option" data-action="release"><span class="key">X</span><span>Dejar ir</span></button>
   </div>
   <div id="carry" class="carry hidden">
-    <div class="option"><span class="key">X</span><span>Soltar</span></div>
+    <div class="option"><span class="key">X</span><span>Dejar ir</span></div>
     <div class="option"><span class="key">G</span><span>Arrodillar</span></div>
   </div>
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- Keep player controls active while targeting an NPC
- Show kneel and release options when aiming, with "Dejar ir" label

## Testing
- `luacheck client/main.lua` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba32f4196c8327a26c520a6ba378c0